### PR TITLE
fixed image flickering bug

### DIFF
--- a/app/lib/ui/tiles/image_tile.dart
+++ b/app/lib/ui/tiles/image_tile.dart
@@ -42,7 +42,7 @@ class _ImageTileState extends State<ImageTile> {
               ),
             ),
             FadeInImage(
-                placeholder: AssetImage('assets/images/dou_placeholder.jpg'),
+                placeholder: AssetImage(widget.item.path),
                 image: AssetImage(widget.item.path))
           ]),
         ),


### PR DESCRIPTION
This pull request fixed the image flickering bug per issue #101, #96, and #95 requests.

By testing locally with AVD and physical devices, the flickering bug has been fixed.

This bug is mainly related to `FadeInImage`, of which in this case released while not in sight and shown the placeholder, constantly recalculate the layout thus cause the flickering problem.

**Screenshot:**

![screenshot 2021-03-14 124634](https://user-images.githubusercontent.com/19504567/111057656-212d3780-84c4-11eb-9f32-a35bbe611286.png)
